### PR TITLE
Removing stackstorm version limitation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## v1.0.1
+
+2018-10-10
+ * Removed stackstorm minimum version as there's no contraints in http-runner to use as http method
+ 
 ## v1.0.0
 
 Initial Release / 2018-10-08

--- a/pack.yaml
+++ b/pack.yaml
@@ -4,6 +4,6 @@ description: Integration between StackStorm and Nginx Plus
 keywords:
     - nginx
     - nginx-plus
-version: 1.0.0
+version: 1.0.1
 author: Copart
 email: igor.cherkaev@copart.com

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,4 +7,3 @@ keywords:
 version: 1.0.0
 author: Copart
 email: igor.cherkaev@copart.com
-stackstorm_version: '>=2.10.0'


### PR DESCRIPTION
Http-runner doesn't limit us with which http method to run it. The pack can be used with any stackstorm release as long as it has http-runner.